### PR TITLE
refactor: use html links instead of md link

### DIFF
--- a/examples/04-pill/README.md
+++ b/examples/04-pill/README.md
@@ -7,7 +7,7 @@ The goal of this example is to show how to:
 1. create an ordinary key (ECC NIST P256) and to store its content in the filesystem
 1. load the key into the TPM
 
-[`create_key_test`](./create_key_test.go) on its part demonstrates two concepts described in the pill:
+[`concepts_test.go`](./concepts_test.go) on its part demonstrates two concepts described in the pill:
 
 1. a *Primary key* is reproducible
 1. only *Storage keys* can be used to create an *Ordinary key*

--- a/pills/00-preface.md
+++ b/pills/00-preface.md
@@ -40,11 +40,11 @@ If you want to explore the topic further or if the `TPM Pills` approach simply d
 
 | Resource | Description | Format |
 | --- | --- | --- |
-| [A Practical Guide to TPM 2.0](https://link.springer.com/book/10.1007/978-1-4302-6584-9) | At the time of writing, the most comprehensive book on the subject (my bedside book)! <br><br>***Note: PDF format is free*** | Book |
-|  OST2 courses | <ul><li>[Trusted Computing 1101: Introductory Trusted Platform Module (TPM) Usage](https://ost2.fyi/TC1101)</li><li>[Trusted Computing 1102: Intermediate Trusted Platform Module (TPM) Usage](https://ost2.fyi/TC1102)</li></ul> ***Note: courses are free*** | Online course |
-| [TPM.dev tutorials](https://github.com/tpm2dev/tpm.dev.tutorials) | To share developer-friendly resources about Trusted Platform Modules (TPM) and hardware security, including other Hardware Security Modules (HSM). <br><br>*Note: description from the repo*  | Tutorials |
-| [TPM-JS by Google](https://github.com/tpm2dev/tpm.dev.tutorials) | TPM-JS lets you experiment with a software TPM device in your browser. It's an educational tool that teaches you how to use a TPM device to secure your workflows. <br><br>*Note: description from the repo*<br><br>***Warning: the repo is archived since 2022***  | Tutorials |
-| [TPMCourse by Nokia](https://github.com/nokia/TPMCourse) | A short course on getting started with understanding how a TPM 2.0 works. In this course we explain a number of the features of the TPM 2.0 through the TPM2_Tools through examples and, optionally, exercises.<br><br>*Note: description from the repo*  | Tutorials |
+| <a href="https://link.springer.com/book/10.1007/978-1-4302-6584-9" target="_blank">A Practical Guide to TPM 2.0</a> | At the time of writing, the most comprehensive book on the subject (my bedside book)! <br><br>***Note: PDF format is free*** | Book |
+|  OST2 courses | <ul><li><a href="https://ost2.fyi/TC1101" target="_blank">Trusted Computing 1101: Introductory Trusted Platform Module (TPM) Usage</a></li><li><a href="https://ost2.fyi/TC1102" target="_blank">Trusted Computing 1102: Intermediate Trusted Platform Module (TPM) Usage</a></li></ul> ***Note: courses are free*** | Online course |
+| <a href="https://github.com/tpm2dev/tpm.dev.tutorials" target="_blank">TPM.dev tutorials</a> | To share developer-friendly resources about Trusted Platform Modules (TPM) and hardware security, including other Hardware Security Modules (HSM). <br><br>*Note: description from the repo*  | Tutorials |
+| <a href="https://github.com/tpm2dev/tpm.dev.tutorials" target="_blank">TPM-JS by Google</a> | TPM-JS lets you experiment with a software TPM device in your browser. It's an educational tool that teaches you how to use a TPM device to secure your workflows. <br><br>*Note: description from the repo*<br><br>***Warning: the repo is archived since 2022***  | Tutorials |
+| <a href="https://github.com/nokia/TPMCourse" target="_blank">TPMCourse by Nokia</a> | A short course on getting started with understanding how a TPM 2.0 works. In this course we explain a number of the features of the TPM 2.0 through the TPM2_Tools through examples and, optionally, exercises.<br><br>*Note: description from the repo*  | Tutorials |
 
 <p align="center"><b>Table: </b><em>Educational Resources</em></p>
 
@@ -58,8 +58,8 @@ I'm far from being an expert on the subject, but I want to contribute to the dem
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 💬
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a> 💬
 
-[^1]: The specification available [here](https://trustedcomputinggroup.org/resource/tpm-library-specification) is a dense and relatively complex document.
+[^1]: The specification available <a href="https://trustedcomputinggroup.org/resource/tpm-library-specification" target="_blank">here</a> is a dense and relatively complex document.
 [^2]: Version 184 released on March 2025

--- a/pills/01-why-tpm-is-super-dope.md
+++ b/pills/01-why-tpm-is-super-dope.md
@@ -20,15 +20,15 @@ For example, this concept can be applied during a machine's *boot* process, wher
 
 ![](./images/01-pill/boot.png)
 
-These measurements could be stored in memory or on the *filesystem*, but that would allow a *malware* to alter them. Conversely, the TPM is a standalone component [^4] dedicated to this task and incapable of executing code from external sources (e.g. malware).  
+These measurements could be stored in memory or on the *filesystem*, but that would allow a *malware* to alter them. Conversely, the TPM is a standalone component [^4] dedicated to this task and incapable of executing code from external sources (e.g. malware).
 
-Similarly, a TPM solves the issue of storing a secret on disk. Historically, this problem was simply shifted, leading to the following situation: *« I will encrypt my secret with a symmetric key* 💡 *but where should I store this key?!* 🤯».  
+Similarly, a TPM solves the issue of storing a secret on disk. Historically, this problem was simply shifted, leading to the following situation: *« I will encrypt my secret with a symmetric key* 💡 *but where should I store this key?!* 🤯».
 
 Fortunately for us, the TPM elegantly solves this problem by providing the encryption key (which is not exportable).
 
 ![](./images/01-pill/seal_unseal.png)
 
-This type of principle is used, for example, by [BitLocker](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/) or systemd (i.e.  [systemd-cryptenroll](https://www.freedesktop.org/software/systemd/man/latest/systemd-cryptenroll.html)).  
+This type of principle is used, for example, by <a href="https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/" target="_blank">BitLocker</a> or systemd (i.e.  <a href="https://www.freedesktop.org/software/systemd/man/latest/systemd-cryptenroll.html" target="_blank">systemd-cryptenroll</a>).  
 
 It is even possible to combine these two concepts and ensure that the `unseal` mechanism is only allowed **if the machine is in a trusted state**, thanks to integrity measurements. We will explore this in more depth in the upcoming *pills*, but this already gives you a glimpse of the vast capabilities provided by a TPM.
 
@@ -42,7 +42,7 @@ TCG has also produced other specs that revolve around TPMs.
 
 ## Different kinds of TPM
 
-***Note:** this section quotes content from [TPM 2.0: A Brief Introduction](https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-A-Brief-Introduction.pdf) produced by TCG (Trusted Computing Group).*
+***Note:** this section quotes content from <a href="https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-A-Brief-Introduction.pdf" target="_blank">TPM 2.0: A Brief Introduction</a> produced by TCG (Trusted Computing Group).*
 
 You need to have in mind that there are different kinds of TPMs, each with its own security level and cost. The choice of a TPM will depend on the security level required by the system and the budget allocated to it:
 
@@ -86,7 +86,7 @@ For the sake of impartiality, I must highlight the drawbacks inherent in using a
 
 ### What's about Apple devices?
 
-Contrary to Microsoft and Linux, Apple made the decision to use a proprietary solution called [Secure Enclave](https://support.apple.com/guide/security/sec59b0b31ff/web).
+Contrary to Microsoft and Linux, Apple made the decision to use a proprietary solution called <a href="https://support.apple.com/guide/security/sec59b0b31ff/web" target="_blank">Secure Enclave</a>.
 
 <div class="info">
 <b>Tip</b>
@@ -102,13 +102,13 @@ If you are a macOS user, you can still stay with us because most of the examples
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 💬
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a> 💬
 
 
-[^1]: Hardware Security Module (see more in [Wikipedia](https://en.wikipedia.org/wiki/Hardware_security_module))
-[^2]: see more in [Wikipedia](https://en.wikipedia.org/wiki/Smart_card)
+[^1]: Hardware Security Module (see more in <a href="https://en.wikipedia.org/wiki/Hardware_security_module" target="_blank">Wikipedia</a>)
+[^2]: see more in <a href="https://en.wikipedia.org/wiki/Smart_card" target="_blank">Wikipedia</a>
 [^3]: via a `Secure Boot` or a `Measured Boot`.
 [^4]: it has its own memory (RAM) and its own storage, although the resources are very limited.
-[^5]: [Window 11 - System requirements](https://www.microsoft.com/en-us/windows/windows-11-specifications?r=1#table1)
+[^5]: <a href="https://www.microsoft.com/en-us/windows/windows-11-specifications?r=1#table1" target="_blank">Window 11 - System requirements</a>
 [^6]: This decision by a tech giant led to a drop in TPM prices.

--- a/pills/02-install-tooling.md
+++ b/pills/02-install-tooling.md
@@ -4,7 +4,7 @@ The goal here is to prepare your environment to run the examples provided in `TP
 
 ## Disclaimer regarding Windows  
 
-So far, my experience with TPMs has been exclusively limited to a **Linux** context — this is why, I am open to [feedback](https://github.com/loicsikidi/tpm-pills/issues) from Windows users, if they encounter any issues.  
+So far, my experience with TPMs has been exclusively limited to a **Linux** context — this is why, I am open to <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">feedback</a> from Windows users, if they encounter any issues.  
 
 <div class="warning">
 <b>Warning</b>
@@ -18,16 +18,16 @@ Unfortunately, according to <a href="https://github.com/microsoft/WSL/issues/517
 
 | Tool | Description | Linux Support | Windows Support | MacOS Support |  
 | ---- | ----------- | :-----------: | :-------------: | :-----------: |  
-|  **[go](https://go.dev/)** >= `v1.22` | A language that no longer needs an introduction | ✅ | ✅ | ✅ |  
-|  **[openssl](https://github.com/openssl/openssl)** | Crypto *Swiss Army Knife* which here is a dependency for using the Software TPM | ✅ | ✅ | ✅ |
-|  **[swtpm](https://github.com/stefanberger/swtpm)** | A Software TPM Emulator | ✅ |  ✅ <br><br> ([using Cygwin](https://github.com/stefanberger/swtpm/wiki#compile-and-install-on-cygwin)) |  ✅ |  
-|  **[tpm2-tools](https://github.com/tpm2-software/tpm2-tools)** | A CLI (*Command-Line Interface*) for interacting with a TPM | ✅ | ❌ | ❌ |  
+|  **<a href="https://go.dev/" target="_blank">go</a>** >= `v1.22` | A language that no longer needs an introduction | ✅ | ✅ | ✅ |
+|  **<a href="https://github.com/openssl/openssl" target="_blank">openssl</a>** | Crypto *Swiss Army Knife* which here is a dependency for using the Software TPM | ✅ | ✅ | ✅ |
+|  **<a href="https://github.com/stefanberger/swtpm" target="_blank">swtpm</a>** | A Software TPM Emulator | ✅ |  ✅ <br><br> (<a href="https://github.com/stefanberger/swtpm/wiki#compile-and-install-on-cygwin" target="_blank">using Cygwin</a>) |  ✅ |
+|  **<a href="https://github.com/tpm2-software/tpm2-tools" target="_blank">tpm2-tools</a>** | A CLI (*Command-Line Interface*) for interacting with a TPM | ✅ | ❌ | ❌ |  
 
 <p align="center"><b>Table: </b><em>Tooling support per Operating System</em></p>
 
 `tpm2-tools` is a great tool to have in your *toolbox*! However, since it is not available everywhere, it will be used sparingly.  
 
-> *Note: `PowerShell` provides some [commands](https://learn.microsoft.com/en-us/powershell/module/trustedplatformmodule) to interact with a TPM, but they will not be covered here.* 
+> *Note: `PowerShell` provides some <a href="https://learn.microsoft.com/en-us/powershell/module/trustedplatformmodule" target="_blank">commands</a> to interact with a TPM, but they will not be covered here.* 
 
 ### Why `go`?  
 
@@ -35,10 +35,10 @@ Most educational content on the subject is in **C**... but why follow the crowd,
 
 More seriously:  
 
-* I am not an experienced **C** developer, but I am proficient in **Go**  
-* [`go-tpm`](https://github.com/google/go-tpm) provides a rich interface for communicating with a TPM  
+* I am not an experienced **C** developer, but I am proficient in **Go**
+* <a href="https://github.com/google/go-tpm" target="_blank">`go-tpm`</a> provides a rich interface for communicating with a TPM
 * In the upcoming *pills*, we will make the TPM interact with a server in gRPC, and **Go** allows me to do this easily
-* More and more projects in Golang ecosystem use TPMs (e.g., [spire](https://github.com/spiffe/spire), [sks](https://github.com/facebookincubator/sks), [u-root](https://github.com/u-root/u-root), [constellation](https://github.com/edgelesssys/constellation), etc.)
+* More and more projects in Golang ecosystem use TPMs (e.g., <a href="https://github.com/spiffe/spire" target="_blank">spire</a>, <a href="https://github.com/facebookincubator/sks" target="_blank">sks</a>, <a href="https://github.com/u-root/u-root" target="_blank">u-root</a>, <a href="https://github.com/edgelesssys/constellation" target="_blank">constellation</a>, etc.)
 
 Fundamentally, since the `TPM 2.0` interface is a standard, all the concepts we will cover here are also applicable in other languages.  
 
@@ -48,14 +48,14 @@ For those interested, here is a (probably non-exhaustive) list of TPM 2.0 client
 
 | Name | Language | Description |
 | ---- | -------- | ----------- |
-| [tpm2-tss](https://github.com/tpm2-software/tpm2-tss) | C | Intel implementation of TCG's TPM Software Stack (TSS). The current standard meter bar regarding TPM libraries. |
-| [ibmtss](https://github.com/kgoldman/ibmtss) | C | IBM implementation of TPM Software Stack (TSS) but not API compatible with TCG TSS. |
-| [wolfTPM](https://github.com/wolfSSL/wolfTPM) | C | TPM 2.0 librairy designed for embedded system. |
-| [go-tpm](https://github.com/google/go-tpm) | golang | |
-| [tpm2-pytss](https://github.com/tpm2-software/tpm2-pytss) | python | Wrapper of `tpm2-tss`. |
-| [tpm-rs](https://github.com/tpm-rs/tpm-rs)| rust | |
-| [rust-tss-fapi](https://github.com/tpm2-software/rust-tss-fapi)| rust | Wrapper of `libtss2-fapi` which is an upper API provided by `tpm2-tss` named FAPI[^1]. <br><br>***Warning**: project's maintainers underline that the implementation is experimental and shouldn't be use in production*. |
-| [TSS.MSR](https://github.com/microsoft/TSS.MSR)| c#, c++, java, nodejs and python | |
+| <a href="https://github.com/tpm2-software/tpm2-tss" target="_blank">tpm2-tss</a> | C | Intel implementation of TCG's TPM Software Stack (TSS). The current standard meter bar regarding TPM libraries. |
+| <a href="https://github.com/kgoldman/ibmtss" target="_blank">ibmtss</a> | C | IBM implementation of TPM Software Stack (TSS) but not API compatible with TCG TSS. |
+| <a href="https://github.com/wolfSSL/wolfTPM" target="_blank">wolfTPM</a> | C | TPM 2.0 librairy designed for embedded system. |
+| <a href="https://github.com/google/go-tpm" target="_blank">go-tpm</a> | golang | |
+| <a href="https://github.com/tpm2-software/tpm2-pytss" target="_blank">tpm2-pytss</a> | python | Wrapper of `tpm2-tss`. |
+| <a href="https://github.com/tpm-rs/tpm-rs" target="_blank">tpm-rs</a>| rust | |
+| <a href="https://github.com/tpm2-software/rust-tss-fapi" target="_blank">rust-tss-fapi</a>| rust | Wrapper of `libtss2-fapi` which is an upper API provided by `tpm2-tss` named FAPI[^1]. <br><br>***Warning**: project's maintainers underline that the implementation is experimental and shouldn't be use in production*. |
+| <a href="https://github.com/microsoft/TSS.MSR" target="_blank">TSS.MSR</a>| c#, c++, java, nodejs and python | |
 
 <p align="center"><b>Table: </b><em>TPM libraries</em></p>
 
@@ -69,7 +69,7 @@ For those interested, here is a (probably non-exhaustive) list of TPM 2.0 client
 
 If you are a Nix user, `TPM Pills` provides a Nix shell (i.e. `shell.nix`) at the root of the repository.  
 
-To install dependencies, simply run the following commands:  
+To install dependencies, simply run the following commands:
 
 ```bash
 git clone https://github.com/loicsikidi/tpm-pills.git
@@ -84,17 +84,17 @@ tpm2 --version
 
 > *Note: with this method `tpm2-tools` will only be installed on a Linux platform.*
 
-### Devbox  
+### Devbox
 
 <div class="info">
 <b>Info</b>
 
  For those who are unfamiliar, <a href="https://github.com/jetify-com/devbox" target="_blank">Devbox</a> is a layer on top of <b>Nix</b> that allows you to obtain a deterministic shell without having to master the Nix language.
 </div>
-  
-If you are a Devbox user, `TPM Pills` also provides a configuration (i.e. `devbox.json`) at the root of the repository.  
 
-To install dependencies, simply run the following commands:  
+If you are a Devbox user, `TPM Pills` also provides a configuration (i.e. `devbox.json`) at the root of the repository.
+
+To install dependencies, simply run the following commands:
 
 ```bash
 git clone https://github.com/loicsikidi/tpm-pills.git
@@ -109,12 +109,12 @@ tpm2 --version
 
 > *Note: with this method `tpm2-tools` will only be installed on a Linux platform.*
 
-### Manually  
+### Manually
 
-* **go**: Use your preferred *package manager* or download the binary from the [official website](https://go.dev/doc/install)  
-* **openssl**: Use your preferred *package manager* or get the sources from the [official website](https://openssl-library.org/source/)
-* **swtpm**: Use your preferred package manager or build the sources by following the [official documentation](https://github.com/stefanberger/swtpm/wiki)
-* **tpm2-tools**: Use your preferred *package manager* or build the sources by following the [official documentation](https://tpm2-tools.readthedocs.io/en/latest/INSTALL/)
+* **go**: Use your preferred *package manager* or download the binary from the <a href="https://go.dev/doc/install" target="_blank">official website</a>
+* **openssl**: Use your preferred *package manager* or get the sources from the <a href="https://openssl-library.org/source/" target="_blank">official website</a>
+* **swtpm**: Use your preferred package manager or build the sources by following the <a href="https://github.com/stefanberger/swtpm/wiki" target="_blank">official documentation</a>
+* **tpm2-tools**: Use your preferred *package manager* or build the sources by following the <a href="https://tpm2-tools.readthedocs.io/en/latest/INSTALL/" target="_blank">official documentation</a>
 
 ## Example: validate TPM's version
 
@@ -147,7 +147,7 @@ You should get the following output:
 
 The script will works on all environments (on `Darwin`, the code relies on a Software TPM).
 
-Run the following command:  
+Run the following command:
 
 ```bash
 # dependending on your config it might require 'sudo'
@@ -157,7 +157,7 @@ go run github.com/loicsikidi/tpm-pills/examples/02-pill
 # TPM Version: 2.0
 ```
 
-Depending on your local setup, you can also run the following command:  
+Depending on your local setup, you can also run the following command:
 
 ```bash
 # nix command
@@ -174,7 +174,7 @@ devbox run -- go run github.com/loicsikidi/tpm-pills/examples/02-pill
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 💬
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a> 💬
 
 [^1]: Feature API

--- a/pills/03-how-to-interact-with-a-tpm.md
+++ b/pills/03-how-to-interact-with-a-tpm.md
@@ -6,7 +6,7 @@ It’s important to keep in mind that a TPM is primarily a **passive** device. B
 
 ![](./images/03-pill/basic-tpm-interaction.png)
 
-In the <a href="02-install-tooling.html#example-validate-tpms-version" target="_blank">previous pill</a>, we used the `TPM2_GetCapability` command to display the TPM version. This command is very useful because it provides a set of information about a TPM (static data) and its current state (dynamic data). The two libraries (*tpm2-tools and go-tpm*) that we used did more or less the same thing:
+In the <a href="https://tpmpills.com/02-install-tooling.html#example-validate-tpms-version" target="_blank">previous pill</a>, we used the `TPM2_GetCapability` command to display the TPM version. This command is very useful because it provides a set of information about a TPM (static data) and its current state (dynamic data). The two libraries (*tpm2-tools and go-tpm*) that we used did more or less the same thing:
 
 1. The library created the `TPM2_GetCapability` command in accordance with the specification  
 1. The command was sent to the TPM[^2]

--- a/pills/03-how-to-interact-with-a-tpm.md
+++ b/pills/03-how-to-interact-with-a-tpm.md
@@ -32,7 +32,7 @@ Let’s take a closer look at the transmission part (steps 2 and 5), as this is 
 The device is usually named <code class="hljs">/dev/tpm0</code>.
 </div>
 
-As we saw in <a href="01-why-tpm-is-super-dope.html" target="_blank">pill #1</a>, a TPM is characterized by being resource-efficient, which is why it does not natively manage *multi-tenancy* when several applications need to communicate concurrently with it. To address this issue, the TCG produced a specification (*<a href="https://trustedcomputinggroup.org/resource/tss-tab-and-resource-manager/" target="_blank">TCG TSS 2.0 TAB and Resource Manager</a>*) describing how to implement this logic.
+As we saw in <a href="https://tpmpills.com/01-why-tpm-is-super-dope.html" target="_blank">pill #1</a>, a TPM is characterized by being resource-efficient, which is why it does not natively manage *multi-tenancy* when several applications need to communicate concurrently with it. To address this issue, the TCG produced a specification (*<a href="https://trustedcomputinggroup.org/resource/tss-tab-and-resource-manager/" target="_blank">TCG TSS 2.0 TAB and Resource Manager</a>*) describing how to implement this logic.
 
 ![](./images/03-pill/resource-manager-diagram.png)
 

--- a/pills/03-how-to-interact-with-a-tpm.md
+++ b/pills/03-how-to-interact-with-a-tpm.md
@@ -6,7 +6,7 @@ It’s important to keep in mind that a TPM is primarily a **passive** device. B
 
 ![](./images/03-pill/basic-tpm-interaction.png)
 
-In the [previous pill](02-install-tooling.md#example-validate-tpms-version), we used the `TPM2_GetCapability` command to display the TPM version. This command is very useful because it provides a set of information about a TPM (static data) and its current state (dynamic data). The two libraries (*tpm2-tools and go-tpm*) that we used did more or less the same thing:
+In the <a href="02-install-tooling.html#example-validate-tpms-version" target="_blank">previous pill</a>, we used the `TPM2_GetCapability` command to display the TPM version. This command is very useful because it provides a set of information about a TPM (static data) and its current state (dynamic data). The two libraries (*tpm2-tools and go-tpm*) that we used did more or less the same thing:
 
 1. The library created the `TPM2_GetCapability` command in accordance with the specification  
 1. The command was sent to the TPM[^2]
@@ -32,7 +32,7 @@ Let’s take a closer look at the transmission part (steps 2 and 5), as this is 
 The device is usually named <code class="hljs">/dev/tpm0</code>.
 </div>
 
-As we saw in [pill #1](01-why-tpm-is-super-dope.md), a TPM is characterized by being resource-efficient, which is why it does not natively manage *multi-tenancy* when several applications need to communicate concurrently with it. To address this issue, the TCG produced a specification (*[TCG TSS 2.0 TAB and Resource Manager](https://trustedcomputinggroup.org/resource/tss-tab-and-resource-manager/)*) describing how to implement this logic.
+As we saw in <a href="01-why-tpm-is-super-dope.html" target="_blank">pill #1</a>, a TPM is characterized by being resource-efficient, which is why it does not natively manage *multi-tenancy* when several applications need to communicate concurrently with it. To address this issue, the TCG produced a specification (*<a href="https://trustedcomputinggroup.org/resource/tss-tab-and-resource-manager/" target="_blank">TCG TSS 2.0 TAB and Resource Manager</a>*) describing how to implement this logic.
 
 ![](./images/03-pill/resource-manager-diagram.png)
 
@@ -63,9 +63,9 @@ In most distributions, the *devices* dedicated to the TPM are owned by the `root
 
 <p align="center"><em>Screenshot from a NixOS Laptop</em></p>
 
-This has significant implications, as it requires your application to be run with *root* privileges—an unacceptable situation in many contexts (e.g., general public usage). By comparison, a Yubikey will ask the user to enter a PIN or press the device to unlock access to keys, without the underlying driver requiring `root` privileges. The concept of authorization exists on a TPM, so there’s fundamentally nothing preventing a *rootless* approach.
+This has significant implications, as it requires your application to be run with *root* privileges—an unacceptable situation in many contexts (e.g., general public usage). By comparison, a Yubikey will ask the user to enter a PIN or press the device to unlock access to keys, without the underlying driver requiring `root` privileges. The concept of authorization exists on a TPM, so there's fundamentally nothing preventing a *rootless* approach.
 
-Unfortunately, there is no consensus on the subject that would allow all applications to communicate with a TPM in a *rootless* manner. As of now, the ***hack*** consists of requiring the user to install [`tpm2-tss`](https://github.com/tpm2-software/tpm2-tss) in order to benefit from its [*udev rules*](https://github.com/tpm2-software/tpm2-tss/blob/b6fd5147a0618019af0d1d6d597492014354da3b/dist/tpm-udev.rules), which have become a sort of unofficial standard. Admittedly, this method is not ideal, for two reasons:
+Unfortunately, there is no consensus on the subject that would allow all applications to communicate with a TPM in a *rootless* manner. As of now, the ***hack*** consists of requiring the user to install <a href="https://github.com/tpm2-software/tpm2-tss" target="_blank">`tpm2-tss`</a> in order to benefit from its <a href="https://github.com/tpm2-software/tpm2-tss/blob/b6fd5147a0618019af0d1d6d597492014354da3b/dist/tpm-udev.rules" target="_blank">*udev rules*</a>, which have become a sort of unofficial standard. Admittedly, this method is not ideal, for two reasons:
 
 1. It installs a binary that might not even be used  
 2. `tpm2-tss` is not necessarily packaged on all distributions  
@@ -96,20 +96,20 @@ We’ve seen how to interact with a TPM locally, but is it possible to do so rem
 
 As an example, the TCP approach is the one used by many simulators such as:
 
-* [libtpms](https://github.com/stefanberger/libtpms)
-* [swtpm](https://github.com/stefanberger/swtpm)
-* [mssim](https://github.com/microsoft/ms-tpm-20-ref)
+* <a href="https://github.com/stefanberger/libtpms" target="_blank">libtpms</a>
+* <a href="https://github.com/stefanberger/swtpm" target="_blank">swtpm</a>
+* <a href="https://github.com/microsoft/ms-tpm-20-ref" target="_blank">mssim</a>
 
 The most important thing is to remember that this type of access exists. If your context requires it, keep in mind that establishing an encrypted channel is a prerequisite to prevent any *man-in-the-middle* attacks.
 
 ## Bonus: an exotic TPM
 
-It’s worth knowing that a TPM can also be located outside of a machine, for example... on a USB stick! That’s the rather wild idea proposed by [LetsTrust-TPM2Go](https://hackaday.io/project/193028-letstrust-tpm2go/details), offering a portable TPM. 
+It's worth knowing that a TPM can also be located outside of a machine, for example... on a USB stick! That's the rather wild idea proposed by <a href="https://hackaday.io/project/193028-letstrust-tpm2go/details" target="_blank">LetsTrust-TPM2Go</a>, offering a portable TPM.
 
 Technically, this is a TPM that responds to SPI (Serial Peripheral Interface) inputs; then, *libusb* is used to connect the USB device with the host.
 
 ![](./images/03-pill/ltt2go-diagram.png)
-*source: https://github.com/tpm2-software/tpm2-tss/blob/master/doc/tcti.md#tcti-spi-ltt2go*
+*source: <a href="https://github.com/tpm2-software/tpm2-tss/blob/master/doc/tcti.md#tcti-spi-ltt2go" target="_blank">https://github.com/tpm2-software/tpm2-tss/blob/master/doc/tcti.md#tcti-spi-ltt2go</a>*
 
 ## Acknowledgement
 
@@ -133,11 +133,11 @@ In this pill, we’ve seen how we can interact with a TPM and, most importantly,
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 💬
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a> 💬
 
-[^1]:  more precisely in [Part 3: Commands](https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf)
-[^2]: [here](https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=313) in the spec
+[^1]:  more precisely in <a href="https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf" target="_blank">Part 3: Commands</a>
+[^2]: <a href="https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=313" target="_blank">here</a> in the spec
 [^3]: released on July 2, 2017
 [^4]: Remote Procedure Call
-[^5]: these *"drivers"* are an implementation of the TPM Command Transmission Interface (TCTI). Please refer to this [document](https://github.com/tpm2-software/tpm2-tss/blob/master/doc/tcti.md#tcti-cmd) for more information.
+[^5]: these *"drivers"* are an implementation of the TPM Command Transmission Interface (TCTI). Please refer to this <a href="https://github.com/tpm2-software/tpm2-tss/blob/master/doc/tcti.md#tcti-cmd" target="_blank">document</a> for more information.

--- a/pills/04-create-a-tpm-key.md
+++ b/pills/04-create-a-tpm-key.md
@@ -297,7 +297,7 @@ This is by design: a primary key is <b>reproducible</b>.
 
 ### Bonus
 
-The file [04-pill/concepts_test.go](https://github.com/loicsikidi/tpm-pills/tree/main/examples/04-pill/concepts_test.go) includes unit tests that demonstrate key concepts from this pill, including **key reproducibility** and that **only storage keys can have children**.
+The file <a href="https://github.com/loicsikidi/tpm-pills/tree/main/examples/04-pill/concepts_test.go" target="_blank">04-pill/concepts_test.go</a> includes unit tests that demonstrate key concepts from this pill, including **key reproducibility** and that **only storage keys can have children**.
 
 Feel free to check it out if you’re curious.
 
@@ -322,12 +322,12 @@ Then, we applied these ideas in a practical example.
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 💬
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a> 💬
 
 [^1]: if you're familiar with the PKCS#11 protocol, a hierarchy is similar to the concept of a  `token`
 [^2]: with the exception of the NULL hierarchy
 [^3]: this refers to the OEM (Original Equipment Manufacturer)
 [^4]: also referred to as the *primary seed*
-[^5]: see the Wikipedia [article](https://en.wikipedia.org/wiki/Key_derivation_function)
+[^5]: see the Wikipedia <a href="https://en.wikipedia.org/wiki/Key_derivation_function" target="_blank">article</a>
 [^6]: it may have been generated elsewhere and then imported into the TPM

--- a/pills/05-perform-crypto-with-asymmetric-keys.md
+++ b/pills/05-perform-crypto-with-asymmetric-keys.md
@@ -175,7 +175,7 @@ signRsp, _ := tpm2.Sign{
 
 ### Deep dive: signing with a *restricted* key
 
-In the [previous pill](04-create-a-tpm-key.md#key-attributes), we introduced the concept of a *restricted* key. To recap, this property allows a key to sign or encrypt/decrypt TPM-internal objects. Now the question arises: *is it possible to sign external data with a restricted key?* The answer is **yes**, but under certain conditions.
+In the <a href="04-create-a-tpm-key.html#key-attributes" target="_blank">previous pill</a>, we introduced the concept of a *restricted* key. To recap, this property allows a key to sign or encrypt/decrypt TPM-internal objects. Now the question arises: *is it possible to sign external data with a restricted key?* The answer is **yes**, but under certain conditions.
 
 A restricted signing key is mainly used to produce attestations in the `TPMS_ATTEST`[^5] format.
 
@@ -262,13 +262,13 @@ In this pill, we explored how to perform cryptographic operations with an asymme
 
 🚧 `TPM Pills` is in **beta** 🚧
 
-* if you encounter problems 🙏 please report them on the [tpm-pills](https://github.com/loicsikidi/tpm-pills/issues) issue tracker
-* if you think that `TPM Pills` should cover a specific topic which isn't in the [roadmap](https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md), let's initiate a [discussion](https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas) 
+* if you encounter problems 🙏 please report them on the <a href="https://github.com/loicsikidi/tpm-pills/issues" target="_blank">tpm-pills</a> issue tracker
+* if you think that `TPM Pills` should cover a specific topic which isn't in the <a href="https://github.com/loicsikidi/tpm-pills/blob/main/ROADMAP.md" target="_blank">roadmap</a>, let's initiate a <a href="https://github.com/loicsikidi/tpm-pills/discussions/new?category=ideas" target="_blank">discussion</a>
 
 
-[^1]: see [Optimal asymmetric encryption padding article](https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding) on Wikipedia
-[^2]: see [hybrid cryptosystem article](https://en.wikipedia.org/wiki/Hybrid_cryptosystem) on Wikipedia
-[^3]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=110
-[^4]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=165
-[^5]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf#page=158
+[^1]: see <a href="https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding" target="_blank">Optimal asymmetric encryption padding article</a> on Wikipedia
+[^2]: see <a href="https://en.wikipedia.org/wiki/Hybrid_cryptosystem" target="_blank">hybrid cryptosystem article</a> on Wikipedia
+[^3]: <a href="https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=110" target="_blank">https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=110</a>
+[^4]: <a href="https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=165" target="_blank">https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-3-Version-184_pub.pdf#page=165</a>
+[^5]: <a href="https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf#page=158" target="_blank">https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf#page=158</a>
 [^6]: security note: if the payload to be hashed includes the `TPM_GENERATED_VALUE` header, the command will not return a ticket.

--- a/pills/05-perform-crypto-with-asymmetric-keys.md
+++ b/pills/05-perform-crypto-with-asymmetric-keys.md
@@ -175,7 +175,7 @@ signRsp, _ := tpm2.Sign{
 
 ### Deep dive: signing with a *restricted* key
 
-In the <a href="04-create-a-tpm-key.html#key-attributes" target="_blank">previous pill</a>, we introduced the concept of a *restricted* key. To recap, this property allows a key to sign or encrypt/decrypt TPM-internal objects. Now the question arises: *is it possible to sign external data with a restricted key?* The answer is **yes**, but under certain conditions.
+In the <a href="https://tpmpills.com/04-create-a-tpm-key.html#key-attributes" target="_blank">previous pill</a>, we introduced the concept of a *restricted* key. To recap, this property allows a key to sign or encrypt/decrypt TPM-internal objects. Now the question arises: *is it possible to sign external data with a restricted key?* The answer is **yes**, but under certain conditions.
 
 A restricted signing key is mainly used to produce attestations in the `TPMS_ATTEST`[^5] format.
 


### PR DESCRIPTION
Note: this change allow us to force to open a new tab when the user clicks on a link.