### PR TITLE
fix: support mdbook >= v0.5.0 #61

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
         with:
-          # nix_path: nixpkgs=channel:nixos-unstable
-          nix_path: nixpkgs=channel:nixos-25.11
+          nix_path: nixpkgs=channel:nixos-unstable
+          # nix_path: nixpkgs=channel:nixos-25.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Print nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'

--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
         with:
-          # nix_path: nixpkgs=channel:nixos-unstable
-          nix_path: nixpkgs=channel:nixos-25.11
+          nix_path: nixpkgs=channel:nixos-unstable
+          # nix_path: nixpkgs=channel:nixos-25.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build static sources
         run: nix-build -A html-split

--- a/book.toml
+++ b/book.toml
@@ -8,6 +8,7 @@ src = "pills"
 additional-css = ["custom.css"]
 git-repository-url = "https://github.com/loicsikidi/tpm-pills"
 mathjax-support = true
+sidebar-header-nav = true
 
 [output.sitemap-generator]
 domain = "tpmpills.com"

--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,8 @@ in
       buildPhase = ''
         runHook preBuild
 
+        echo "mdbook version: $(mdbook --version)"
+
         mdbook build
 
         runHook postBuild

--- a/nix/pkgs/mdbook-sitemap-generator.nix
+++ b/nix/pkgs/mdbook-sitemap-generator.nix
@@ -4,14 +4,14 @@
 }:
 buildGoModule rec {
   pname = "mdbook-sitemap-generator";
-  version = "1.2.0";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "loicsikidi";
     repo = "mdbook-sitemap-generator";
     tag = "v${version}";
-    hash = "sha256-CGj6sWgOzI2cimX7KE0TkXOR6KlTOk2ZbIb3c5X6TSk=";
+    hash = "sha256-FZ8tfIvosu6L0jWex/uyg+w6QYYxyBSqYWsqu2low+0=";
   };
 
-  vendorHash = "sha256-WUQW8EDJ7kT2CUZsNtlVUVwwqFRHkpkU6pFmx7/MDGg=";
+  vendorHash = "sha256-cEgvwog50izBOyMlCdLI2KvwSHPKZsp1wSw6a59V1yw=";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 let
-  # mdbook pinned to 0.4.52
+  # mdbook pinned to 0.5.2
   # go to https://www.nixhub.io/packages/mdbook to the list of available versions
   nixpkgs =
     fetchTarball
-    "https://github.com/NixOS/nixpkgs/archive/ee09932cedcef15aaf476f9343d1dea2cb77e261.tar.gz";
+    "https://github.com/NixOS/nixpkgs/archive/8482c7ded03bae7550f3d69884f1e611e3bd19e8.tar.gz";
   pkgs = import nixpkgs {
     config = {};
     overlays = [];


### PR DESCRIPTION
Note: v0.5.0 introduces a bunch of breaking changes which broke sitemap-generator plugin. I've created a fork in order to fix the issue (I'll submit the fix to the upstream repo ^^) and now we are ready to go! In addition, this commit re-enable nixpkgs unstable channel to test build job on mdbook latest release.