### PR TITLE
chore(deps): bump to go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loicsikidi/tpm-pills
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006


### PR DESCRIPTION
Note: go 1.24 drop support since 11 Feb 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement to 1.25.0 for building from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->